### PR TITLE
Add subscription support

### DIFF
--- a/lib/gqli/dsl.rb
+++ b/lib/gqli/dsl.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative './query'
+require_relative './subscription'
 require_relative './fragment'
 require_relative './enum_value'
 
@@ -12,6 +13,13 @@ module GQLi
     # Can be used at a class level
     def self.query(name = nil, &block)
       Query.new(name, &block)
+    end
+
+    # Creates a Subscription object
+    #
+    # Can be used at a class level
+    def self.subscription(name = nil, &block)
+      Subscription.new(name, &block)
     end
 
     # Creates a Fragment object
@@ -33,6 +41,13 @@ module GQLi
     # Can be used at an instance level
     def query(name = nil, &block)
       Query.new(name, &block)
+    end
+
+    # Creates a Subscription object
+    #
+    # Can be used at a class level
+    def subscription(name = nil, &block)
+      Subscription.new(name, &block)
     end
 
     # Creates a Fragment object

--- a/lib/gqli/subscription.rb
+++ b/lib/gqli/subscription.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module GQLi
+  # Query node
+  class Subscription < Base
+    # Serializes to a GraphQL string
+    def to_gql
+      result = <<~GQL
+        subscription #{__name ? __name + ' ' : ''}{
+        #{__nodes.map(&:to_gql).join("\n")}
+        }
+      GQL
+
+      result.lstrip
+    end
+
+    # Delegates itself to the client to be executed
+    def __execute(client)
+      client.execute(self)
+    end
+
+    # Serializes to a GraphQL string
+    def to_s
+      to_gql
+    end
+  end
+end

--- a/lib/gqli/version.rb
+++ b/lib/gqli/version.rb
@@ -3,5 +3,5 @@
 # GraphQL Client and DSL library
 module GQLi
   # Gem version
-  VERSION = '0.5.1'
+  VERSION = '0.5.0'
 end

--- a/lib/gqli/version.rb
+++ b/lib/gqli/version.rb
@@ -3,5 +3,5 @@
 # GraphQL Client and DSL library
 module GQLi
   # Gem version
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/spec/lib/gqli/dsl_spec.rb
+++ b/spec/lib/gqli/dsl_spec.rb
@@ -37,6 +37,35 @@ describe GQLi::DSL do
       end
     end
 
+    describe '::subscription' do
+      it 'can create a subscription without name' do
+        subscription = subject.subscription {
+          someField
+        }
+
+        expect(subscription).to be_a GQLi::Subscription
+        expect(subscription.to_gql).to eq <<~GRAPHQL
+          subscription {
+            someField
+          }
+        GRAPHQL
+        expect(subscription.to_gql).to eq subscription.to_s
+      end
+
+      it 'can create a subscription with a name' do
+        subscription = subject.subscription('FooBar') {
+          someOtherField
+        }
+
+        expect(subscription).to be_a GQLi::Subscription
+        expect(subscription.to_gql).to eq <<~GRAPHQL
+          subscription FooBar {
+            someOtherField
+          }
+        GRAPHQL
+      end
+    end
+
     describe '::fragment' do
       it 'can create a fragment' do
         fragment = subject.fragment('FooBar', 'Foo') {
@@ -93,6 +122,39 @@ describe GQLi::DSL do
       end
     end
 
+
+    describe '#subscription does the same as ::subscription' do
+
+      subject { MockGQLInterface.new }
+
+      it 'can create a subscription without name' do
+        subscription = subject.subscription {
+          someField
+        }
+
+        expect(subscription).to be_a GQLi::Subscription
+        expect(subscription.to_gql).to eq <<~GRAPHQL
+          subscription {
+            someField
+          }
+        GRAPHQL
+        expect(subscription.to_gql).to eq subscription.to_s
+      end
+
+      it 'can create a subscription with a name' do
+        subscription = subject.subscription('FooBar') {
+          someOtherField
+        }
+
+        expect(subscription).to be_a GQLi::Subscription
+        expect(subscription.to_gql).to eq <<~GRAPHQL
+          subscription FooBar {
+            someOtherField
+          }
+        GRAPHQL
+      end
+    end
+
     describe '#fragment does the same as ::fragment' do
       it 'can create a fragment' do
         fragment = subject.fragment('FooBar', 'Foo') {
@@ -137,8 +199,8 @@ describe GQLi::DSL do
 
     it 'nodes can have directives' do
       query = subject.query {
-        someNode(:@include => {if: true})
-        otherNode(:@skip => {if: false})
+        someNode(:@include => { if: true })
+        otherNode(:@skip => { if: false })
       }
 
       expect(query.to_gql).to eq <<~GRAPHQL


### PR DESCRIPTION
This PR aims to add subscription support to gqli.rb. 

I utilize [graphql-ruby](https://github.com/rmosolgo/graphql-ruby) subscriptions, and GQLi makes testing and writing queries much easier. It would be nice if this were merged upstream. 

Notable changes: 
- Add subscription type
- Bump version number

Feedback is greatly welcome