### PR TITLE
Bump http.rb dependency version

### DIFF
--- a/gqli.gemspec
+++ b/gqli.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'http', '> 0.8', '< 3.0'
+  gem.add_dependency 'http', '> 0.8', '< 6.0'
   gem.add_dependency 'hashie', '~> 3.0'
   gem.add_dependency 'multi_json', '~> 1'
 


### PR DESCRIPTION
The `http.rb` < 4.4.1 doesn't work in Ruby 3.0. See: https://github.com/httprb/http/issues/640