### PR TITLE
Add GitLab client constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v1.2.0
+### Added
+* Client constructor for GitLab. (@lukes)
+
 ## v1.1.0
 * Added support for timeout management. [#11](https://github.com/contentful-labs/gqli.rb/pull/11)
 * Added support for error response handling. [#13](https://github.com/contentful-labs/gqli.rb/pull/13)

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ gem 'gqli'
 
 ### Creating a GraphQL Client
 
-For the examples throughout this README, we'll be using the Contentful and Github GraphQL APIs, for which we have factory methods.
-Therefore, here's the initialization code required for both of them:
+For the examples throughout this README, we'll be using the Contentful, Github, and GitLab GraphQL APIs,
+for which we have factory methods. Therefore, here's the initialization code required for them:
 
 ```ruby
 require 'gqli'
@@ -43,6 +43,15 @@ CONTENTFUL_GQL = GQLi::Contentful.create(SPACE_ID, CF_ACCESS_TOKEN)
 # Creating a Github GraphQL Client
 GITHUB_ACCESS_TOKEN = ENV['GITHUB_TOKEN']
 GITHUB_GQL = GQLi::Github.create(GITHUB_ACCESS_TOKEN)
+
+# Creating a GitLab GraphQL Client
+# As an anonymous user to GitLab.com:
+GITLAB_GQL = GQLi::GitLab.create
+# As an authenticated user (to GitLab.com):
+GITLAB_ACCESS_TOKEN = ENV['GITLAB_TOKEN']
+GITLAB_GQL = GQLi::GitLab.create(GITLAB_ACCESS_TOKEN)
+# To your GitLab self-managed instance:
+GITLAB_GQL = GQLi::GitLab.create(GITLAB_ACCESS_TOKEN, api: 'https://myinstance.org/api/graphql')
 ```
 
 *Note*: Please feel free to contribute factories for your favorite GraphQL services.

--- a/lib/gqli/clients.rb
+++ b/lib/gqli/clients.rb
@@ -2,3 +2,4 @@
 
 require_relative './clients/contentful'
 require_relative './clients/github'
+require_relative './clients/gitlab'

--- a/lib/gqli/clients/gitlab.rb
+++ b/lib/gqli/clients/gitlab.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module GQLi
+  # Module for creating a GitLab GraphQL client
+  module GitLab
+    # Creates a GitLab GraphQL client
+    def self.create(access_token = nil, api: 'https://gitlab.com/api/graphql', validate_query: true, options: {})
+      headers = {}
+      headers['Authorization'] = "Bearer #{access_token}" if access_token
+
+      GQLi::Client.new(
+        api,
+        headers: headers,
+        validate_query: validate_query,
+        options: options
+      )
+    end
+  end
+end

--- a/lib/gqli/version.rb
+++ b/lib/gqli/version.rb
@@ -3,5 +3,5 @@
 # GraphQL Client and DSL library
 module GQLi
   # Gem version
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/lib/gqli/client_spec.rb
+++ b/spec/lib/gqli/client_spec.rb
@@ -49,6 +49,32 @@ describe GQLi::Client do
 
       expect(client).to be_a(GQLi::Client)
     end
+
+    describe 'gitlab client' do
+      it 'can build a client without Authorization headers' do
+        client = GQLi::GitLab.create(validate_query: false)
+
+        expect(client).to be_a(GQLi::Client)
+        expect(client.headers).to be_empty
+        expect(client.url).to eq('https://gitlab.com/api/graphql')
+      end
+
+      it 'can build a client with Authorization headers' do
+        client = GQLi::GitLab.create('foobar', validate_query: false)
+
+        expect(client).to be_a(GQLi::Client)
+        expect(client.headers).to eq({'Authorization' => 'Bearer foobar'})
+        expect(client.url).to eq('https://gitlab.com/api/graphql')
+      end
+
+      it 'can build a client to a self-managed GitLab instance' do
+        client = GQLi::GitLab.create(api: 'https://foo.com', validate_query: false)
+
+        expect(client).to be_a(GQLi::Client)
+        expect(client.headers).to be_empty
+        expect(client.url).to eq('https://foo.com')
+      end
+    end
   end
 
   describe 'query can call the client to execute' do


### PR DESCRIPTION
Hi!

I've added a GitLab client constructor. Unfortunately I haven't been able to have bundler resolve the gem dependencies, so wasn't able to run the specs. Please could you check out this branch and make sure the specs run for me!

You can test the client using an unauthenticated request:

```ruby

GITLAB_GQL = GQLi::GitLab.create

ProjectQuery = GQLi::DSL.query {
  project(fullPath: "gitlab-org/gitlab") {
    name
  }
}

GITLAB_GQL.execute(ProjectQuery)
```