### PR TITLE
Bump hashie dependency

### DIFF
--- a/gqli.gemspec
+++ b/gqli.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'http', '> 0.8', '< 3.0'
-  gem.add_dependency 'hashie', '~> 3.0'
+  gem.add_dependency 'hashie', '> 3.0'
   gem.add_dependency 'multi_json', '~> 1'
 
   gem.add_development_dependency 'rake', '< 11.0'


### PR DESCRIPTION
There's version 4 of Hashie gem (almost 2 years ago according to https://github.com/hashie/hashie/blob/master/CHANGELOG.md#400---2019-10-30)

I can't play with your gem due to this (I use 4.1.0 in my project)