### PR TITLE
Relax http dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
+* Relax http dependency (support version < 6).
 
 ## v1.1.0
 * Added support for timeout management. [#11](https://github.com/contentful-labs/gqli.rb/pull/11)

--- a/gqli.gemspec
+++ b/gqli.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'http', '> 0.8', '< 3.0'
+  gem.add_dependency 'http', '> 0.8', '< 6.0'
   gem.add_dependency 'hashie', '~> 3.0'
   gem.add_dependency 'multi_json', '~> 1'
 


### PR DESCRIPTION
This PR simply allows newer versions of http, which is needed for ruby 3.x.
See also https://github.com/httprb/http/issues/582